### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10276,7 +10276,7 @@
       "integrity": "sha512-8iSa4mGNXBjyuSZFCCO4fiKfvzqk+mhL0lnKuGcQtO1eoj8nq3CmbEG8FwK5QqoqwDgsjsf1GDuisDX4cdb/aQ=="
     },
     "vue-server-renderer": {
-      "version": "2.6.11",
+      "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.11.tgz",
       "integrity": "sha512-V3faFJHr2KYfdSIalL+JjinZSHYUhlrvJ9pzCIjjwSh77+pkrsXpK4PucdPcng57+N77pd1LrKqwbqjQdktU1A==",
       "requires": {


### PR DESCRIPTION
Fixes error of vue-server-renderer version mismatch.

多分、vueのバージョンを上げたら済む気もするのですが、vue-server-renderer のバージョンが違うっていうエラーが出てたので一応修正してPRしておきます。